### PR TITLE
add JSON and YAML input parsing

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,7 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.194.0/containers/rust/.devcontainer/base.Dockerfile
+
+FROM mcr.microsoft.com/vscode/devcontainers/rust:0-1
+
+# [Optional] Uncomment this section to install additional packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,41 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.194.0/containers/rust
+{
+	"name": "Rust",
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
+	"runArgs": [
+		"--cap-add=SYS_PTRACE",
+		"--security-opt",
+		"seccomp=unconfined"
+	],
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": {
+		"lldb.executable": "/usr/bin/lldb",
+		// VS Code don't watch files under ./target
+		"files.watcherExclude": {
+			"**/target/**": true
+		},
+		"rust-analyzer.checkOnSave.command": "clippy"
+	},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"vadimcn.vscode-lldb",
+		"mutantdino.resourcemonitor",
+		"matklad.rust-analyzer",
+		"tamasfe.even-better-toml",
+		"serayuzgur.crates"
+	],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "rustc --version",
+
+	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "vscode"
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,51 @@
 version = 3
 
 [[package]]
+name = "ansi_term"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "clap"
+version = "2.33.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+dependencies = [
+ "ansi_term",
+ "atty",
+ "bitflags",
+ "strsim",
+ "textwrap",
+ "unicode-width",
+ "vec_map",
+]
 
 [[package]]
 name = "commander"
@@ -15,6 +56,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "structopt",
 ]
 
 [[package]]
@@ -28,6 +70,24 @@ name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
+name = "heck"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "indexmap"
@@ -46,10 +106,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "libc"
+version = "0.2.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2a5ac8f984bfcf3a823267e5fde638acc3325f6496633a5da6bb6eb2171e103"
+
+[[package]]
 name = "linked-hash-map"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -119,6 +215,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "structopt"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf9d950ef167e25e0bdb073cf1d68e9ad2795ac826f2f3f59647817cf23c0bfa"
+dependencies = [
+ "clap",
+ "lazy_static",
+ "structopt-derive",
+]
+
+[[package]]
+name = "structopt-derive"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "134d838a2c9943ac3125cf6df165eda53493451b719f3255b2a26b85f772d0ba"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -130,10 +256,65 @@ dependencies = [
 ]
 
 [[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+
+[[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+
+[[package]]
+name = "version_check"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "yaml-rust"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,143 @@
 version = 3
 
 [[package]]
+name = "autocfg"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+
+[[package]]
 name = "commander"
 version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "serde_yaml",
+]
+
+[[package]]
+name = "dtoa"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
+
+[[package]]
+name = "hashbrown"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
+name = "indexmap"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
+dependencies = [
+ "autocfg",
+ "hashbrown",
+]
+
+[[package]]
+name = "itoa"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9f5105d4fdaab20335ca9565e106a5d9b82b6219b5ba735731124ac6711d23d"
+dependencies = [
+ "unicode-xid",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "ryu"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+
+[[package]]
+name = "serde"
+version = "1.0.130"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f12d06de37cf59146fbdecab66aa99f9fe4f78722e3607577a5375d66bd0c913"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.130"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7bc1a1ab1961464eae040d96713baa5a724a8152c1222492465b54322ec508b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f690853975602e1bfe1ccbf50504d67174e3bcf340f23b5ea9992e0587a52d8"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8c608a35705a5d3cdc9fbe403147647ff34b921f8e833e49306df898f9b20af"
+dependencies = [
+ "dtoa",
+ "indexmap",
+ "serde",
+ "yaml-rust",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f107db402c2c2055242dbf4d2af0e69197202e9faacbef9571bbe47f5a1b84"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,4 @@ edition = "2018"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.8"
+structopt = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,6 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+serde_yaml = "0.8"

--- a/fixtures/input.json
+++ b/fixtures/input.json
@@ -1,0 +1,23 @@
+[
+  {
+    "executable": "/bin/bash",
+    "arguments": [
+      "1",
+      "duo",
+      "three"
+    ]
+  },
+  {
+    "executable": "/scripts/command",
+    "arguments": []
+  },
+  {
+    "executable": "/bin/ps"
+  },
+  {
+    "executable": "/bin/ps",
+    "arguments": [
+      "-ef"
+    ]
+  }
+]

--- a/fixtures/input.yaml
+++ b/fixtures/input.yaml
@@ -9,4 +9,4 @@
 - executable: /bin/ps
 - executable: /bin/ps
   arguments:
-  - -ef
+  - -1

--- a/fixtures/input.yaml
+++ b/fixtures/input.yaml
@@ -1,0 +1,12 @@
+---
+- executable: /bin/bash
+  arguments:
+  - 1
+  - duo
+  - three
+- executable: /scripts/command
+  arguments: []
+- executable: /bin/ps
+- executable: /bin/ps
+  arguments:
+  - -ef

--- a/src/command_line.rs
+++ b/src/command_line.rs
@@ -14,6 +14,11 @@ impl CommandLine {
         let text = read_to_string(path)?;
         Ok(serde_yaml::from_str::<Vec<CommandLine>>(&text)?)
     }
+
+    fn from_json(path: &str) -> Result<Vec<Self>> {
+        let text = read_to_string(path)?;
+        Ok(serde_json::from_str::<Vec<CommandLine>>(&text)?)
+    }
 }
 
 impl From<std::io::Error> for Error {
@@ -27,6 +32,13 @@ impl From<serde_yaml::Error> for Error {
         Error::new(err.to_string())
     }
 }
+
+impl From<serde_json::Error> for Error {
+    fn from(err: serde_json::Error) -> Self {
+        Error::new(err.to_string())
+    }
+}
+
 #[derive(Debug)]
 struct Error {
     message: String,
@@ -116,10 +128,9 @@ fn parse_json_file_into_commands() {
         },
     ];
 
-    let input = std::fs::read_to_string("./fixtures/input.json").unwrap();
     assert_eq!(
         commands,
-        serde_json::from_str::<Vec<CommandLine>>(&input).unwrap()
+        CommandLine::from_json("./fixtures/input.json").unwrap()
     );
 }
 

--- a/src/command_line.rs
+++ b/src/command_line.rs
@@ -1,0 +1,118 @@
+use serde::Deserialize;
+
+/// Commandline represents one executable command and its arguments
+#[derive(Debug, PartialEq, Deserialize)]
+pub struct CommandLine {
+    executable: String,
+    arguments: Option<Vec<String>>,
+}
+
+#[test]
+fn parse_yaml_input() {
+    let input = r#"
+---
+executable: /bin/bash
+arguments:
+- 1
+- duo
+- three
+"#;
+    let cmd = CommandLine {
+        executable: String::from("/bin/bash"),
+        arguments: Some(vec![
+            "1".to_string(),
+            "duo".to_string(),
+            "three".to_string(),
+        ]),
+    };
+
+    assert_eq!(cmd, serde_yaml::from_str(input).unwrap())
+}
+
+#[test]
+fn parse_json_input() {
+    let input = r#"
+{
+  "executable": "/bin/bash",
+  "arguments": [
+    "1",
+    "duo",
+    "three"
+   ]
+}
+"#;
+    let cmd = CommandLine {
+        executable: "/bin/bash".to_string(),
+        arguments: Some(vec![
+            "1".to_string(),
+            "duo".to_string(),
+            "three".to_string(),
+        ]),
+    };
+
+    assert_eq!(cmd, serde_json::from_str(input).unwrap())
+}
+
+#[test]
+fn parse_json_file_into_commands() {
+    let commands = vec![
+        CommandLine {
+            executable: "/bin/bash".to_string(),
+            arguments: Some(vec![
+                "1".to_string(),
+                "duo".to_string(),
+                "three".to_string(),
+            ]),
+        },
+        CommandLine {
+            executable: "/scripts/command".to_string(),
+            arguments: Some(vec![]),
+        },
+        CommandLine {
+            executable: "/bin/ps".to_string(),
+            arguments: None,
+        },
+        CommandLine {
+            executable: "/bin/ps".to_string(),
+            arguments: Some(vec!["-ef".to_string()]),
+        },
+    ];
+
+    let input = std::fs::read_to_string("./fixtures/input.json").unwrap();
+    assert_eq!(
+        commands,
+        serde_json::from_str::<Vec<CommandLine>>(&input).unwrap()
+    );
+}
+
+#[test]
+fn parse_yaml_file_into_commands() {
+    let commands = vec![
+        CommandLine {
+            executable: "/bin/bash".to_string(),
+            arguments: Some(vec![
+                "1".to_string(),
+                "duo".to_string(),
+                "three".to_string(),
+            ]),
+        },
+        CommandLine {
+            executable: "/scripts/command".to_string(),
+            arguments: Some(vec![]),
+        },
+        CommandLine {
+            executable: "/bin/ps".to_string(),
+            arguments: None,
+        },
+        CommandLine {
+            executable: "/bin/ps".to_string(),
+            arguments: Some(vec!["-ef".to_string()]),
+        },
+    ];
+
+    let input = std::fs::read_to_string("./fixtures/input.yaml").unwrap();
+    assert_eq!(
+        commands,
+        serde_yaml::from_str::<Vec<CommandLine>>(&input).unwrap()
+    );
+}

--- a/src/command_line.rs
+++ b/src/command_line.rs
@@ -1,6 +1,7 @@
 use serde::Deserialize;
 use std::fmt::{Display, Formatter};
 use std::fs::read_to_string;
+use std::process::Command;
 
 /// Commandline represents one executable command and its arguments
 #[derive(Debug, PartialEq, Deserialize)]
@@ -10,14 +11,23 @@ pub struct CommandLine {
 }
 
 impl CommandLine {
-    fn from_yaml(path: &str) -> Result<Vec<Self>> {
+    pub(crate) fn from_yaml(path: &str) -> Result<Vec<Self>> {
         let text = read_to_string(path)?;
         Ok(serde_yaml::from_str::<Vec<CommandLine>>(&text)?)
     }
 
-    fn from_json(path: &str) -> Result<Vec<Self>> {
+    pub(crate) fn from_json(path: &str) -> Result<Vec<Self>> {
         let text = read_to_string(path)?;
         Ok(serde_json::from_str::<Vec<CommandLine>>(&text)?)
+    }
+}
+impl From<&CommandLine> for Command {
+    fn from(item: &CommandLine) -> Self {
+        let mut command = Command::new(item.executable.clone());
+        for args in item.arguments.as_ref().into_iter() {
+            command.args(args);
+        }
+        command
     }
 }
 
@@ -40,7 +50,7 @@ impl From<serde_json::Error> for Error {
 }
 
 #[derive(Debug)]
-struct Error {
+pub(crate) struct Error {
     message: String,
 }
 

--- a/src/command_line.rs
+++ b/src/command_line.rs
@@ -165,7 +165,7 @@ fn parse_yaml_file_into_commands() {
         },
         CommandLine {
             executable: "/bin/ps".to_string(),
-            arguments: Some(vec!["-ef".to_string()]),
+            arguments: Some(vec!["-1".to_string()]),
         },
     ];
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,63 @@
 mod command_line;
 
-#[allow(unused_imports)]
+use crate::command_line::CommandLine;
+use std::path::PathBuf;
+use std::process;
 use std::process::Command;
+use structopt::StructOpt;
 
-fn main() {
-    println!("Hello, world!");
+#[derive(Debug, StructOpt)]
+#[structopt(name = "commander", about = "Running many command lines")]
+struct Opt {
+    /// Activate debug mode
+    #[structopt(short, long)]
+    debug: bool,
+    /// Input file
+    #[structopt(parse(from_os_str))]
+    file: PathBuf,
+    #[structopt(short, default_value = "yaml")]
+    input_type: String,
+}
+
+fn main() -> Result<(), command_line::Error> {
+    let opt = Opt::from_args();
+
+    let filename = match opt.file.as_path().to_str() {
+        Some(filename) => filename,
+        None => {
+            eprintln!("can't get a filename");
+            process::exit(1)
+        }
+    };
+
+    let commands = match opt.input_type.as_ref() {
+        "yaml" => CommandLine::from_yaml(filename)?,
+        "json" => CommandLine::from_json(filename)?,
+        _ => {
+            eprintln!("unsupported file type");
+            process::exit(1)
+        }
+    };
+
+    for command_line in commands.iter() {
+        let mut command = Command::from(command_line);
+        let output = command.output();
+        match output {
+            Ok(output) => {
+                println!(
+                    "{}",
+                    std::str::from_utf8(&output.stdout).unwrap_or_default()
+                );
+                eprintln!(
+                    "{}",
+                    std::str::from_utf8(&output.stderr).unwrap_or_default()
+                );
+            }
+            Err(e) => eprintln!("command failed: {}", e),
+        }
+    }
+
+    Ok(())
 }
 
 #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,6 @@
+mod command_line;
+
+#[allow(unused_imports)]
 use std::process::Command;
 
 fn main() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,9 +9,6 @@ use structopt::StructOpt;
 #[derive(Debug, StructOpt)]
 #[structopt(name = "commander", about = "Running many command lines")]
 struct Opt {
-    /// Activate debug mode
-    #[structopt(short, long)]
-    debug: bool,
     /// Input file
     #[structopt(parse(from_os_str))]
     file: PathBuf,


### PR DESCRIPTION
- [x] JSON parsing
- [x] YAML parsing

Example run:

```
→ cargo r -- fixtures/input.yaml 2>/dev/null
  PID TTY           TIME CMD
69293 ttys002    0:00.59 /bin/zsh --login
84135 ttys002    0:00.01 tmux new
69299 ttys003    0:00.36 /bin/zsh --login
84139 ttys004    0:00.78 -zsh
84211 ttys005    0:00.56 -zsh
24306 ttys006    0:01.96 nvim dns-api-client/lib.rs
24310 ttys006    0:29.48 rust-analyzer
24330 ttys006    0:00.50 /Users/marcosvm/.cargo/bin/rust-analyzer proc-macro
94960 ttys006    0:01.63 -zsh
95043 ttys007    0:01.25 -zsh
16088 ttys008    0:02.22 -zsh
57386 ttys008    0:00.14 target/debug/commander fixtures/input.yaml
57387 ttys008    0:00.01 pbcopy
16094 ttys009    0:01.78 -zsh
50239 ttys010    0:00.24 /bin/zsh -l
52980 ttys010    0:00.00 /bin/zsh -l
52984 ttys010    0:17.65 fzf
28133 ttys011    0:00.57 -zsh
44845 ttys011    0:00.93 /Applications/Xcode.app/Contents/Developer/usr/bin/git grep PathBuf
44846 ttys011    0:00.01 /usr/bin/less
28139 ttys012    0:00.39 -zsh
50245 ttys013    0:00.11 /bin/zsh -l

  PID TTY           TIME CMD
    1 ??        27:46.47 /sbin/launchd
```

```
→ cargo r -- fixtures/input.yaml 1>/dev/null
    Finished dev [unoptimized + debuginfo] target(s) in 0.02s
     Running `target/debug/commander fixtures/input.yaml`
/bin/bash: 1: No such file or directory

command failed: No such file or directory (os error 2)
```

Fix https://github.com/marcosvm/commander/issues/4